### PR TITLE
Merge tag and tags yaml data, confirm Remove All

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ export default class QuickTagPlugin extends Plugin {
 			new QuickTagSelector(this.app, this.settings, 'remove').open();
 		});
 
-		// Quick Tagger Logic testing
+		// Quick Tagger Add tag modal command
 		this.addCommand({
 			id: 'quick-add-tag',
 			name: 'Add Tag',
@@ -36,7 +36,7 @@ export default class QuickTagPlugin extends Plugin {
 			}
 		});
 
-		// Quick Tagger Modal
+		// Quick Tagger Remove tag modal command
 		this.addCommand({
 			id: 'open-quick-tagger',
 			name: 'Remove Tag',

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -1,4 +1,4 @@
-import { App, FuzzySuggestModal, Plugin, Setting } from "obsidian";
+import { App, FuzzySuggestModal, Modal, Setting } from "obsidian";
 import {removeTag, addTag, getTagList, getExistingTags} from "./utilities"
 import {QuickTaggerSettings} from "./main"
 
@@ -16,6 +16,7 @@ export class QuickTagSelector extends FuzzySuggestModal<string> {
     mode: number
     func: Function
     tagArray: Array<string>
+    confirm: boolean
 
     constructor (app: App, settings: QuickTaggerSettings, mode: string){
         super(app)
@@ -31,7 +32,54 @@ export class QuickTagSelector extends FuzzySuggestModal<string> {
     }
 
     // Perform action on the selected suggestion
-    onChooseItem(tag: string, evt: MouseEvent | KeyboardEvent) {
-        this.func(tag)
+    async onChooseItem(tag: string, evt: MouseEvent | KeyboardEvent) {
+        if (tag == "REMOVE ALL"){
+            this.confirm = await new Promise((resolve, reject) => {  // add a promise to wait for confirmation
+                new ConfirmRemoveAllModal(app, (result) => (resolve(this.confirm = result))).open()
+            })
+        } else {
+            this.confirm = true
+        }
+        if (this.confirm){
+            this.func(tag)
+        }
     }
+}
+
+
+class ConfirmRemoveAllModal extends Modal {
+    onSubmit: (result: boolean) => void;
+
+	constructor(app: App, onSubmit: (result: boolean) => void) {
+		super(app);
+        this.onSubmit = onSubmit
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+        contentEl.createEl("h1", { text: "This will delete all tags on the current note, are you certain?" })
+		
+        new Setting(contentEl).addButton((btn) =>
+          btn
+            .setButtonText("Yes")
+            .setCta()
+            .onClick(() => {
+                this.close()
+                this.onSubmit(true)
+            }))
+        .addButton((btn) =>
+          btn
+            .setButtonText("No")
+            .setCta()
+            .onClick(() => {
+                this.close()
+                this.onSubmit(false)
+            }))
+	}
+
+	async onClose() {
+		const {contentEl} = this;
+		contentEl.empty();
+	}
+
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -139,10 +139,10 @@ function getTagList(app: App, settings: QuickTaggerSettings){
 }
 
 export function getExistingTags(app: App, settings: QuickTaggerSettings){
-	// TODO: this can be updated to work with category tags (user creates template note with categores
-	//       and this gets existing tags on that note?)
-	const markdownView = markdownViewCheck(app)
-  if (!markdownView){return}
+    // TODO: this can be updated to work with category tags (user creates template note with categores
+    //       and this gets existing tags on that note?)
+    const markdownView = markdownViewCheck(app)
+    if (!markdownView){return}
 
 	var note_content = markdownView.getViewData()
 	note_content = prepYaml(note_content, ['tags'])


### PR DESCRIPTION
This PR adds a modal to confirm removing all tags and also solves a workflow issue where the plugin didn't pick up tags if they were added to the yaml header using the 'tag' key rather than 'tags'.